### PR TITLE
Develop

### DIFF
--- a/auris_tools/configuration.py
+++ b/auris_tools/configuration.py
@@ -3,8 +3,10 @@ import os
 
 from dotenv import load_dotenv
 
-# Load environment variables from .env file
-load_dotenv()
+IN_LAMBDA = bool(os.environ.get('AWS_EXECUTION_ENV'))
+
+if not IN_LAMBDA:
+    load_dotenv()
 
 
 class AWSConfiguration:
@@ -21,21 +23,36 @@ class AWSConfiguration:
         profile: str = None,
         endpoint_url: str = None,
     ):
-        # Try to get credentials from environment variables first
-        self.access_key = (
-            access_key if access_key else os.environ.get('AWS_ACCESS_KEY_ID')
+        self._running_in_lambda = bool(os.environ.get('AWS_EXECUTION_ENV'))
+
+        env_access_key = (
+            None
+            if self._running_in_lambda
+            else os.environ.get('AWS_ACCESS_KEY_ID')
         )
-        self.secret_key = (
-            secret_key
-            if secret_key
+        env_secret_key = (
+            None
+            if self._running_in_lambda
             else os.environ.get('AWS_SECRET_ACCESS_KEY')
         )
+
+        # Try to get credentials from environment variables first
+        self.access_key = access_key if access_key else env_access_key
+        self.secret_key = secret_key if secret_key else env_secret_key
         self.region = (
             region
             if region
             else os.environ.get('AWS_DEFAULT_REGION') or 'us-east-1'
         )
-        self.profile = profile if profile else os.environ.get('AWS_PROFILE')
+        self.profile = (
+            profile
+            if profile
+            else (
+                None
+                if self._running_in_lambda
+                else os.environ.get('AWS_PROFILE')
+            )
+        )
         self.endpoint_url = (
             endpoint_url
             if endpoint_url
@@ -47,6 +64,8 @@ class AWSConfiguration:
 
     def _validate_config(self):
         """Validate that we have enough configuration to proceed."""
+        if self._running_in_lambda:
+            return
         if not ((self.access_key and self.secret_key) or self.profile):
             logging.warning(
                 'No AWS credentials provided via environment variables or constructor. '

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "auris_tools"
-version = "0.0.3"
+version = "0.1.0"
 description = "The swiss knife tools to coordinates cloud frameworks with an easy for Auris platforms"
 authors = [
     {name = "Antonio Senra",email = "acsenrafilho@gmail.com"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "auris_tools"
-version = "0.1.0"
+version = "0.1.1"
 description = "The swiss knife tools to coordinates cloud frameworks with an easy for Auris platforms"
 authors = [
     {name = "Antonio Senra",email = "acsenrafilho@gmail.com"}

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -173,3 +173,29 @@ class TestAWSConfiguration:
         """Test no validation warning when profile is provided."""
         config = AWSConfiguration(profile=self.test_profile)
         mock_warning.assert_not_called()
+
+    @patch.dict(
+        os.environ,
+        {
+            'AWS_EXECUTION_ENV': 'AWS_Lambda_python3.12',
+            'AWS_ACCESS_KEY_ID': 'env-key',
+            'AWS_SECRET_ACCESS_KEY': 'env-secret',
+            'AWS_DEFAULT_REGION': 'us-west-2',
+            'AWS_PROFILE': 'env-profile',
+        },
+        clear=True,
+    )
+    def test_lambda_env_ignores_env_credentials(self):
+        """Ensure Lambda uses execution role instead of env credentials."""
+        config = AWSConfiguration()
+        session_args = config.get_boto3_session_args()
+        assert session_args == {'region_name': 'us-west-2'}
+
+    @patch.dict(
+        os.environ, {'AWS_EXECUTION_ENV': 'AWS_Lambda_python3.12'}, clear=True
+    )
+    @patch('logging.warning')
+    def test_validate_config_no_warning_in_lambda(self, mock_warning):
+        """Do not emit warnings when running inside Lambda."""
+        AWSConfiguration()
+        mock_warning.assert_not_called()


### PR DESCRIPTION
This pull request enhances the handling of AWS credentials in the `auris_tools` package, especially when running inside AWS Lambda environments. The changes ensure that environment variables for AWS credentials are ignored in Lambda, relying instead on the execution role, and that unnecessary warnings are suppressed in such contexts. The update also includes new tests to verify this behavior and bumps the package version.

**AWS Lambda environment handling:**

* Updated `auris_tools/configuration.py` so that when running inside AWS Lambda (`AWS_EXECUTION_ENV` is set), environment variables for AWS credentials and profile are ignored, and no credential validation warnings are emitted. This ensures the code relies on the Lambda execution role for authentication. [[1]](diffhunk://#diff-cfa254aaef99bc0368848d50ba0c90b3da4557b6e083575e3f3b0741605dc920L6-R8) [[2]](diffhunk://#diff-cfa254aaef99bc0368848d50ba0c90b3da4557b6e083575e3f3b0741605dc920L24-R55) [[3]](diffhunk://#diff-cfa254aaef99bc0368848d50ba0c90b3da4557b6e083575e3f3b0741605dc920R67-R68)

**Testing improvements:**

* Added tests in `tests/test_configuration.py` to confirm that environment credentials are ignored and no warnings are logged when running in Lambda.

**Version update:**

* Bumped the package version from `0.0.3` to `0.1.1` in `pyproject.toml`.